### PR TITLE
Fix parser when SCIM begins with a NOT

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -144,14 +144,17 @@ describe('parse', () =>{
     );
     test(
       `not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
-      and(op("ne", "userType", "Employee"), {
-        op: "not",
-        filter: or(
-          op("co", "emails", "example.com"),
-          op("co", "emails", "example.org")
-        )
-      })
-    )
+      and(
+        {
+          op: "not",
+          filter: or(
+            op("co", "emails", "example.com"),
+            op("co", "emails", "example.org")
+          )
+        },
+        op("ne", "userType", "Employee")
+      )
+    );
     test(
       `userType eq "Employee" and (emails.type eq "work")`,
       and(eq("userType", "Employee"), eq("emails.type", "work"))

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -143,6 +143,16 @@ describe('parse', () =>{
       })
     );
     test(
+      `not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
+      and(op("ne", "userType", "Employee"), {
+        op: "not",
+        filter: or(
+          op("co", "emails", "example.com"),
+          op("co", "emails", "example.org")
+        )
+      })
+    )
+    test(
       `userType eq "Employee" and (emails.type eq "work")`,
       and(eq("userType", "Employee"), eq("emails.type", "work"))
     );


### PR DESCRIPTION
This currently just adds a failing test case. I will be attempting to fix the bug in this PR as well, but I only have 2 working days at Okta left, so this might have to be taken up by someone else.

Fixes #55 