### PR TITLE
Fix parser when SCIM begins with a NOT and add more tests

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -84,9 +84,7 @@ export function parseExpression(list: TokenList): Filter {
     return filter;
   } else if (t.literal.toLowerCase() == "not") {
     const notFilter: NotFilter = { op: "not", filter: parseExpression(list) };
-    const op = list.peek().literal.toLowerCase();
-    const p = PRECEDENCE[op];
-    return parseInxif(notFilter, list, p);
+    return parseInxif(notFilter, list, Precedence.NOT);
   } else if (t.type == "Word") {
     return readValFilter(t, list);
   } else {
@@ -96,11 +94,13 @@ export function parseExpression(list: TokenList): Filter {
 enum Precedence {
   LOWEST = 1,
   OR = 2,
-  AND = 3
+  AND = 3,
+  NOT = 4
 }
 const PRECEDENCE: { [key: string]: Precedence } = {
   'or': Precedence.OR,
-  'and': Precedence.AND
+  'and': Precedence.AND,
+  'not': Precedence.NOT
 }
 function parseInxif(left: Filter, list: TokenList, precede: Precedence): Filter {
   const op = list.peek().literal.toLowerCase();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,6 @@
 import { Filter, Compare, NotFilter, Suffix, ValuePath } from ".";
 
-type TokenType = "Number" | "Quoted" | "Blacket" | "Word" | "EOT";
+type TokenType = "Number" | "Quoted" | "Bracket" | "Word" | "EOT";
 const EOT = { type: "EOT" as TokenType, literal: "" };
 
 export type Token = {
@@ -20,7 +20,7 @@ export function tokenizer(f: string): Token[] {
     } else if (n[3]) {
       ret.push({ literal: n[3], type: "Quoted" });
     } else if (n[4]) {
-      ret.push({ literal: n[4], type: "Blacket" });
+      ret.push({ literal: n[4], type: "Bracket" });
     } else if (n[5]) {
       ret.push({ literal: n[5], type: "Word" });
     }
@@ -83,38 +83,41 @@ export function parseExpression(list: TokenList): Filter {
     }
     return filter;
   } else if (t.literal.toLowerCase() == "not") {
-    return { op: "not", filter: parseFilter(list) } as NotFilter;
+    const notFilter: NotFilter = { op: "not", filter: parseExpression(list) };
+    const op = list.peek().literal.toLowerCase();
+    const p = PRECEDENCE[op];
+    return parseInxif(notFilter, list, p);
   } else if (t.type == "Word") {
     return readValFilter(t, list);
   } else {
     throw new Error(`Unexpected token ${t.literal} (${t.type})`);
   }
 }
-enum Precedence{
+enum Precedence {
   LOWEST = 1,
   OR = 2,
   AND = 3
 }
-const PRECEDENCE : { [key:string]: Precedence }= {
-  'or':Precedence.OR,
-  'and':Precedence.AND
+const PRECEDENCE: { [key: string]: Precedence } = {
+  'or': Precedence.OR,
+  'and': Precedence.AND
 }
 function parseInxif(left: Filter, list: TokenList, precede: Precedence): Filter {
   const op = list.peek().literal.toLowerCase();
   const p = PRECEDENCE[op];
-  if(!p || precede >= p){
+  if (!p || precede >= p) {
     return left;
   }
   const filters = [left];
   while (list.peek().literal.toLowerCase() === op) {
     let r = parseExpression(list.forward());
     const rr = list.peek().literal.toLowerCase();
-    if(PRECEDENCE[rr] > p){
+    if (PRECEDENCE[rr] > p) {
       r = parseInxif(r, list, p);
     }
     filters.push(r);
   }
-  return parseInxif({ op , filters } as Filter, list, precede);
+  return parseInxif({ op, filters } as Filter, list, precede);
 }
 function readValFilter(left: Token, list: TokenList): Filter {
   if (left.type !== "Word") {

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -2,7 +2,7 @@ import { Filter } from ".";
 
 export function stringify(f: Filter, trimParens = true): string {
   let returnValue = '';
-  switch(f.op) {
+  switch (f.op) {
     case "eq":
     case "ne":
     case "co":
@@ -18,9 +18,11 @@ export function stringify(f: Filter, trimParens = true): string {
       returnValue = `${f.attrPath} ${f.op}`;
       break;
     case "or":
-    case "and":
       const filtersAsString = f.filters.map(filter => stringify(filter, false)).join(` ${f.op} `);
       returnValue = `(${filtersAsString})`;
+      break;
+    case "and":
+      returnValue = f.filters.map(filter => stringify(filter, false)).join(` ${f.op} `);
       break;
     case "not":
       returnValue = `${f.op} (${stringify(f.filter, true)})`;
@@ -30,7 +32,7 @@ export function stringify(f: Filter, trimParens = true): string {
       break;
   }
   if (trimParens) {
-    returnValue = returnValue.replace(/^\(/, '').replace(/\)$/, '');
+    returnValue = returnValue.replace(/(^\()(.*)(\)$)/, '$2');
   }
   return returnValue;
 }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -10,7 +10,7 @@ const test = (text: string, e: Filter) => {
     assert.deepEqual(parse(text), e);
   });
 };
-describe('parse', () =>{
+describe('parse', () => {
   describe("logic", () => {
     function to_s(f: Filter): any {
       switch (f.op) {
@@ -145,6 +145,49 @@ describe('parse', () =>{
         )
       })
     );
+    test(
+      `not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
+      and(
+        {
+          op: "not",
+          filter: or(
+            op("co", "emails", "example.com"),
+            op("co", "emails", "example.org")
+          )
+        },
+        op("ne", "userType", "Employee")
+      )
+    );
+  test(
+    `userType eq "Employee" and not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
+    and(
+      op("eq", "userType", "Employee"),
+      {
+        op: "not",
+        filter: or(
+          op("co", "emails", "example.com"),
+          op("co", "emails", "example.org")
+        )
+      },
+      op("ne", "userType", "Employee")
+    )
+  );
+  test(
+    `userType eq "Employee" or not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
+    or(
+      op("eq", "userType", "Employee"),
+      and(
+        {
+          op: "not",
+          filter: or(
+            op("co", "emails", "example.com"),
+            op("co", "emails", "example.org")
+          )
+        },
+        op("ne", "userType", "Employee")
+      )
+    )
+  );
     test(
       `userType eq "Employee" and (emails.type eq "work")`,
       and(eq("userType", "Employee"), eq("emails.type", "work"))

--- a/test/stringify.test.ts
+++ b/test/stringify.test.ts
@@ -10,7 +10,7 @@ const test = (text: string, e: Filter) => {
     assert.deepEqual(stringify(e), text);
   });
 };
-describe('stringify', () =>{
+describe('stringify', () => {
   describe("logic", () => {
     function teq(e: string, a: Filter) {
       assert.deepEqual(stringify(a), stringify(parse(e)), e);
@@ -175,6 +175,49 @@ describe('stringify', () =>{
         eq('userType', 'employee'),
         eq('userType', 'admin')
       ))
+    );
+    test(
+      `not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
+      and(
+        {
+          op: "not",
+          filter: or(
+            op("co", "emails", "example.com"),
+            op("co", "emails", "example.org")
+          )
+        },
+        op("ne", "userType", "Employee")
+      )
+    );
+    test(
+      `userType eq "Employee" and not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
+      and(
+        op("eq", "userType", "Employee"),
+        {
+          op: "not",
+          filter: or(
+            op("co", "emails", "example.com"),
+            op("co", "emails", "example.org")
+          )
+        },
+        op("ne", "userType", "Employee")
+      )
+    );
+    test(
+      `userType eq "Employee" or not (emails co "example.com" or emails co "example.org") and userType ne "Employee"`,
+      or(
+        op("eq", "userType", "Employee"),
+        and(
+          {
+            op: "not",
+            filter: or(
+              op("co", "emails", "example.com"),
+              op("co", "emails", "example.org")
+            )
+          },
+          op("ne", "userType", "Employee")
+        )
+      )
     );
   });
 });


### PR DESCRIPTION
- Fix parser when SCIM begins with a NOT, issue [#55](https://github.com/thomaspoignant/scim2-parse-filter/issues/55) 
- Fix stringfy for `and` op
- Add more tests