### PR TITLE
feat: support sub-attributes after value paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "filter"
   ],
   "scripts": {
-    "watch": "mocha -r ts-node/register  'test/**/*.ts' 'src/**/*.ts' -w --watch-extensions ts",
+    "watch": "mocha -r ts-node/register 'test/**/*.ts' 'src/**/*.ts' -w --watch-extensions ts",
     "build": "tsc",
     "test": "npm run build && mocha 'lib/test/**/*.test.js'"
   },

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -230,6 +230,30 @@ describe('parse', () => {
       and(eq("userType", "Employee"), v("emails", and(eq("type", "work"), op("co", "value", "@example.com"))))
     );
     test(
+        `emails[type eq "work"] and emails.value eq "user@example.com"`,
+      and(
+        v("emails", eq("type", "work")),
+        eq("emails.value", "user@example.com"),
+      )
+    );
+    test(
+      `emails[type eq "work"].value eq "user@example.com"`,
+      and(
+        v("emails", eq("type", "work")),
+        eq("emails.value", "user@example.com"),
+      )
+    );
+    test(
+      `emails[type eq "work"].value eq "user@example.com" and name eq "foo"`,
+      and(
+        and(
+          v("emails", eq("type", "work")),
+          eq("emails.value", "user@example.com"),
+        ),
+        eq("name", "foo"),
+      )
+    );
+    test(
       `emails[type eq "work" and value co "@example.com"] or ims[type eq "xmpp" and value co "@foo.com"]`,
       or(
         v("emails", and(eq("type", "work"), op("co", "value", "@example.com"))),

--- a/test/tokenizer.test.ts
+++ b/test/tokenizer.test.ts
@@ -6,15 +6,18 @@ const assert = chai.assert;
 
 describe("tokenizer", () => {
   const tok = (literal: string, type: string) => ({ literal, type } as Token);
+
   it("eot", () => {
     assert.deepEqual(tokenizer(""), [EOT]);
   });
+
   it("false", () => {
     assert.deepEqual(tokenizer("false"), [
       { literal: "false", type: "Word" },
       EOT
     ]);
   });
+
   it("userName is AttrPath", () => {
     assert.deepEqual(tokenizer("userName"), [
       { literal: "userName", type: "Word" },
@@ -28,4 +31,22 @@ describe("tokenizer", () => {
       tokenizer("userName eq -12")
     );
   });
+
+  it("sub-attribute after ValPath", () => {
+    assert.deepEqual(
+        tokenizer('emails[type eq "work"].value eq "user@example.com"'),
+        [
+          tok("emails", "Word"),
+          tok("[", "Bracket"),
+          tok("type", "Word"),
+          tok("eq", "Word"),
+          tok("\"work\"", "Quoted"),
+          tok("].", "Bracket"),
+          tok("value", "Word"),
+          tok("eq", "Word"),
+          tok("\"user@example.com\"", "Quoted"),
+          EOT,
+      ]
+    )
+  })
 });


### PR DESCRIPTION
Allow comparison operations on sub-attributes following value paths. e.g. `emails[type eq "work"].value eq "user@example.com"`

The tokenizer regex was updated to allow for a trailing dot (.) after a closing square bracket (]) when searching for "Bracket" tokens. `readValFilter` was then updated to look for any dot after the closing bracket and a following "Word" token. When this happens an implicit `and` op is returned.

One issue with this approach is that any `and` ops before or after this syntax will result in nested `and` ops instead of a single op with more than two filters. Check the last test added to `parse.test.ts` for an example. However, I couldn't figure out a neat way to flattening that use case without a much more disruptive changeset.

fixes: #96