### PR TITLE
fix: shielding backslash in quotes

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -18,7 +18,8 @@ export function tokenizer(f: string): Token[] {
     } else if (n[2]) {
       ret.push({ literal: n[2], type: "Number" });
     } else if (n[3]) {
-      ret.push({ literal: n[3], type: "Quoted" });
+      const literal = n[3].replace(/\\/g, '\\\\');
+      ret.push({ literal, type: "Quoted" });
     } else if (n[4]) {
       ret.push({ literal: n[4], type: "Bracket" });
     } else if (n[5]) {

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -20,4 +20,12 @@ describe("filter", () => {
         const ret = users.filter(f);
         assert.deepEqual(ret, [users[0]]);
     });
+    it("end to end shielding backslash in quotes", () => {
+        const f = filter(parse(`userName eq "domain\\user.name"`));
+        const users = [
+            { userName: "domain\\user.name" }
+        ];
+        const ret = users.filter(f);
+        assert.deepEqual(ret, users);
+    });
 });


### PR DESCRIPTION
Hello!

The filter parser crashes with an error if a backslash occurs in quotes:
filter: userName eq "domain%5Cuser.name"
Error: ["domain\user.name"(Quoted)] is not json

Added backslash escaping.