### PR TITLE
Add support for TypeScript with 'none' for module config

### DIFF
--- a/src/flatten.ts
+++ b/src/flatten.ts
@@ -1,4 +1,4 @@
-import { Filter } from ".";
+import { Filter } from "./index";
 
 export const valfilter = (f: Filter, path?: string): Filter => {
   if (path && "attrPath" in f) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { Filter, Compare, NotFilter, Suffix, ValuePath } from ".";
+import { Filter, Compare, NotFilter, Suffix, ValuePath } from "./index";
 
 type TokenType = "Number" | "Quoted" | "Bracket" | "Word" | "EOT";
 const EOT = { type: "EOT" as TokenType, literal: "" };

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,4 +1,4 @@
-import { Filter } from ".";
+import { Filter } from "./index";
 
 export function stringify(f: Filter, wrapOr = false): string {
   let returnValue = '';

--- a/src/tester.ts
+++ b/src/tester.ts
@@ -1,4 +1,4 @@
-import { Filter, Compare } from ".";
+import { Filter, Compare } from "./index";
 
 type CompValue = Compare["compValue"];
 


### PR DESCRIPTION
Importing through `"."` engages the module machinery in TypeScript so it's not possible to import the types into a project with [None](https://www.typescriptlang.org/tsconfig#none) module resolution.

Example import:
```
import * as ImportScim2ParseFilter from "../../node_modules/scim2-parse-filter/lib/src/index";

declare global {
	namespace Scim2ParseFilter {
		export type Filter = ImportScim2ParseFilter.Filter;
	}
	export type Scim2ParseFilter = typeof ImportScim2ParseFilter;
	const Scim2ParseFilter: Scim2ParseFilter;
}

export {};
```
Results in:
```
.../node_modules/scim2-parse-filter/lib/src/stringify.d.ts:1:24: Error TS2792: Cannot find module '.'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the
   'paths' option?
```

This is fixed by importing explicitly from `"./index"` instead.

