### PR TITLE
fix(parser): tokenizator regex for negative numbers

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,7 +10,7 @@ export type Token = {
 export function tokenizer(f: string): Token[] {
   const ret: Token[] = [];
   let rest = f;
-  const patterns = /^(?:(\s+)|(-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?(?![-\w._:\/\)\s]))|("(?:[^"\\]|\\.|\n)*")|([[()]|]\.?)|(\w[-\w._:\/%]*))/;
+  const patterns = /^(?:(\s+)|(-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?(?![-\w._:\/\)]))|("(?:[^"\\]|\\.|\n)*")|([[()]|]\.?)|(\w[-\w._:\/%]*))/;
   let n;
   while ((n = patterns.exec(rest))) {
     if (n[1] || n[0].length === 0) {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -121,6 +121,9 @@ describe('parse', () => {
       `title pr or userType eq "Intern"`,
       or(pr("title"), eq("userType", "Intern"))
     );
+    test('balance lt 10 and title pr', and(op("lt", "balance", 10), pr("title")));
+    test('balance lt -10 and title pr', and(op("lt", "balance", -10), pr("title")));
+    test('balance lt -10 and balance gt -100', and(op("lt", "balance", -10), op("gt", "balance", -100)));
     test(
       `schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"`,
       eq(


### PR DESCRIPTION
## Support negative numbers in the middle of filter expressions

### Problem

Negative numeric values (e.g., `-10`, `-100`) were not being parsed correctly when they appeared in the middle of a filter expression — that is, when followed by whitespace and additional clauses. For example, the following valid SCIM filters would throw:

```
balance lt -10 and balance gt -100
balance lt -10 and title pr
```

**Error:** `unexpected token -10 and balance gt -100`

Negative numbers at the *end* of an expression (e.g., `userName eq -12`) worked fine, which made the bug easy to miss.

### Root Cause

The tokenizer regex in parser.ts used a negative lookahead to guard the number pattern:

```
-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?(?![-\w._:\/\)\s])
```

The `\s` in the lookahead `(?![-\w._:\/\)\s])` caused the entire number match to fail whenever a number was followed by whitespace — i.e., any time it appeared mid-expression. End-of-string had no such character, so trailing negative numbers matched successfully.

### Fix

Removed `\s` from the negative lookahead:

```diff
- /^(?:(\s+)|(-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?(?![-\w._:\/\)\s]))|...)/
+ /^(?:(\s+)|(-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?(?![-\w._:\/\)]))|...)/
```

The lookahead still prevents matching when the `-` is part of a word token (followed by word characters, dots, colons, slashes, etc.), but no longer incorrectly rejects numbers followed by a space.

### Tests

Two previously failing test cases now pass:

- `balance lt -10 and balance gt -100`
- `balance lt -10 and title pr`

All 191 tests pass.